### PR TITLE
merge: fix/prismaclient-instanceof-failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 node_modules
-lib

--- a/lib/adapter.d.ts
+++ b/lib/adapter.d.ts
@@ -1,0 +1,30 @@
+import type { Adapter, Model } from 'casbin';
+import { PrismaClient } from '@prisma/client';
+import { Prisma } from '@prisma/client';
+export declare class PrismaAdapter implements Adapter {
+    #private;
+    filtered: boolean;
+    isFiltered(): boolean;
+    enableFiltered(enabled: boolean): void;
+    /**
+     * @param option It should be PrismaClientOptions or PrismaClient.
+     * You should later call open() to activate it.
+     */
+    constructor(option?: Prisma.PrismaClientOptions | PrismaClient);
+    loadPolicy(model: Model): Promise<void>;
+    /**
+     * loadFilteredPolicy loads policy rules that match the filter from the storage;
+     * use an empty string for selecting all values in a certain field.
+     */
+    loadFilteredPolicy(model: Model, filter: {
+        [key: string]: string[][];
+    }): Promise<void>;
+    savePolicy(model: Model): Promise<boolean>;
+    addPolicy(sec: string, ptype: string, rule: string[]): Promise<void>;
+    addPolicies(sec: string, ptype: string, rules: string[][]): Promise<void>;
+    removePolicy(sec: string, ptype: string, rule: string[]): Promise<void>;
+    removePolicies(sec: string, ptype: string, rules: string[][]): Promise<void>;
+    removeFilteredPolicy(sec: string, ptype: string, fieldIndex: number, ...fieldValues: string[]): Promise<void>;
+    close(): Promise<any>;
+    static newAdapter(option?: Prisma.PrismaClientOptions | PrismaClient): Promise<PrismaAdapter>;
+}

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -1,0 +1,217 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __classPrivateFieldSet = (this && this.__classPrivateFieldSet) || function (receiver, state, value, kind, f) {
+    if (kind === "m") throw new TypeError("Private method is not writable");
+    if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a setter");
+    if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot write private member to an object whose class did not declare it");
+    return (kind === "a" ? f.call(receiver, value) : f ? f.value = value : state.set(receiver, value)), value;
+};
+var __classPrivateFieldGet = (this && this.__classPrivateFieldGet) || function (receiver, state, kind, f) {
+    if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a getter");
+    if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot read private member from an object whose class did not declare it");
+    return kind === "m" ? f : kind === "a" ? f.call(receiver) : f ? f.value : state.get(receiver);
+};
+var _PrismaAdapter_option, _PrismaAdapter_prisma, _PrismaAdapter_open, _PrismaAdapter_loadPolicyLine, _PrismaAdapter_savePolicyLine;
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.PrismaAdapter = void 0;
+const casbin_1 = require("casbin");
+const client_1 = require("@prisma/client");
+class PrismaAdapter {
+    isFiltered() {
+        return this.filtered;
+    }
+    enableFiltered(enabled) {
+        this.filtered = enabled;
+    }
+    /**
+     * @param option It should be PrismaClientOptions or PrismaClient.
+     * You should later call open() to activate it.
+     */
+    constructor(option) {
+        _PrismaAdapter_option.set(this, void 0);
+        _PrismaAdapter_prisma.set(this, void 0);
+        this.filtered = false;
+        _PrismaAdapter_open.set(this, () => __awaiter(this, void 0, void 0, function* () {
+            if (!__classPrivateFieldGet(this, _PrismaAdapter_option, "f")) {
+                __classPrivateFieldSet(this, _PrismaAdapter_option, {}, "f");
+            }
+            if (!__classPrivateFieldGet(this, _PrismaAdapter_prisma, "f")) {
+                __classPrivateFieldSet(this, _PrismaAdapter_prisma, new client_1.PrismaClient(__classPrivateFieldGet(this, _PrismaAdapter_option, "f")), "f");
+            }
+            yield __classPrivateFieldGet(this, _PrismaAdapter_prisma, "f").$connect();
+        }));
+        _PrismaAdapter_loadPolicyLine.set(this, (line, model) => {
+            const result = line.ptype +
+                ', ' +
+                [line.v0, line.v1, line.v2, line.v3, line.v4, line.v5]
+                    .filter((n) => n)
+                    .join(', ');
+            casbin_1.Helper.loadPolicyLine(result, model);
+        });
+        _PrismaAdapter_savePolicyLine.set(this, (ptype, rule) => {
+            const line = { ptype };
+            if (rule.length > 0) {
+                line.v0 = rule[0];
+            }
+            if (rule.length > 1) {
+                line.v1 = rule[1];
+            }
+            if (rule.length > 2) {
+                line.v2 = rule[2];
+            }
+            if (rule.length > 3) {
+                line.v3 = rule[3];
+            }
+            if (rule.length > 4) {
+                line.v4 = rule[4];
+            }
+            if (rule.length > 5) {
+                line.v5 = rule[5];
+            }
+            return line;
+        });
+        if (option && typeof option.$connect === 'function') {
+            // If option is PrismaClient, we use it directly.
+            __classPrivateFieldSet(this, _PrismaAdapter_prisma, option, "f");
+        }
+        else if (option) {
+            __classPrivateFieldSet(this, _PrismaAdapter_option, option, "f");
+        }
+    }
+    loadPolicy(model) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const lines = yield __classPrivateFieldGet(this, _PrismaAdapter_prisma, "f").casbinRule.findMany();
+            for (const line of lines) {
+                __classPrivateFieldGet(this, _PrismaAdapter_loadPolicyLine, "f").call(this, line, model);
+            }
+        });
+    }
+    /**
+     * loadFilteredPolicy loads policy rules that match the filter from the storage;
+     * use an empty string for selecting all values in a certain field.
+     */
+    loadFilteredPolicy(model, filter) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const whereFilter = Object.keys(filter)
+                .map((ptype) => {
+                const policyPatterns = filter[ptype];
+                return policyPatterns.map((policyPattern) => {
+                    return Object.assign(Object.assign(Object.assign(Object.assign(Object.assign(Object.assign({ ptype }, (policyPattern[0] && { v0: policyPattern[0] })), (policyPattern[1] && { v1: policyPattern[1] })), (policyPattern[2] && { v2: policyPattern[2] })), (policyPattern[3] && { v3: policyPattern[3] })), (policyPattern[4] && { v4: policyPattern[4] })), (policyPattern[5] && { v5: policyPattern[5] }));
+                });
+            })
+                .flat();
+            const lines = yield __classPrivateFieldGet(this, _PrismaAdapter_prisma, "f").casbinRule.findMany({
+                where: {
+                    OR: whereFilter,
+                },
+            });
+            lines.forEach((line) => __classPrivateFieldGet(this, _PrismaAdapter_loadPolicyLine, "f").call(this, line, model));
+            this.enableFiltered(true);
+        });
+    }
+    savePolicy(model) {
+        return __awaiter(this, void 0, void 0, function* () {
+            yield __classPrivateFieldGet(this, _PrismaAdapter_prisma, "f").$executeRaw `DELETE FROM casbin_rule;`;
+            const lines = [];
+            const savePolicyType = (ptype) => {
+                const astMap = model.model.get(ptype);
+                if (astMap) {
+                    for (const [ptype, ast] of astMap) {
+                        for (const rule of ast.policy) {
+                            const line = __classPrivateFieldGet(this, _PrismaAdapter_savePolicyLine, "f").call(this, ptype, rule);
+                            lines.push(line);
+                        }
+                    }
+                }
+            };
+            savePolicyType('p');
+            savePolicyType('g');
+            // https://github.com/prisma/prisma-client-js/issues/332
+            yield __classPrivateFieldGet(this, _PrismaAdapter_prisma, "f").casbinRule.createMany({ data: lines });
+            return true;
+        });
+    }
+    addPolicy(sec, ptype, rule) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const line = __classPrivateFieldGet(this, _PrismaAdapter_savePolicyLine, "f").call(this, ptype, rule);
+            yield __classPrivateFieldGet(this, _PrismaAdapter_prisma, "f").casbinRule.create({ data: line });
+        });
+    }
+    addPolicies(sec, ptype, rules) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const processes = [];
+            for (const rule of rules) {
+                const line = __classPrivateFieldGet(this, _PrismaAdapter_savePolicyLine, "f").call(this, ptype, rule);
+                const p = __classPrivateFieldGet(this, _PrismaAdapter_prisma, "f").casbinRule.create({ data: line });
+                processes.push(p);
+            }
+            // https://github.com/prisma/prisma-client-js/issues/332
+            yield Promise.all(processes);
+        });
+    }
+    removePolicy(sec, ptype, rule) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const line = __classPrivateFieldGet(this, _PrismaAdapter_savePolicyLine, "f").call(this, ptype, rule);
+            yield __classPrivateFieldGet(this, _PrismaAdapter_prisma, "f").casbinRule.deleteMany({ where: line });
+        });
+    }
+    removePolicies(sec, ptype, rules) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const processes = [];
+            for (const rule of rules) {
+                const line = __classPrivateFieldGet(this, _PrismaAdapter_savePolicyLine, "f").call(this, ptype, rule);
+                const p = __classPrivateFieldGet(this, _PrismaAdapter_prisma, "f").casbinRule.deleteMany({ where: line });
+                processes.push(p);
+            }
+            // https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-client/transactions#bulk-operations
+            yield Promise.all(processes);
+        });
+    }
+    removeFilteredPolicy(sec, ptype, fieldIndex, ...fieldValues) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const line = { ptype };
+            const idx = fieldIndex + fieldValues.length;
+            if (fieldIndex <= 0 && 0 < idx) {
+                line.v0 = fieldValues[0 - fieldIndex];
+            }
+            if (fieldIndex <= 1 && 1 < idx) {
+                line.v1 = fieldValues[1 - fieldIndex];
+            }
+            if (fieldIndex <= 2 && 2 < idx) {
+                line.v2 = fieldValues[2 - fieldIndex];
+            }
+            if (fieldIndex <= 3 && 3 < idx) {
+                line.v3 = fieldValues[3 - fieldIndex];
+            }
+            if (fieldIndex <= 4 && 4 < idx) {
+                line.v4 = fieldValues[4 - fieldIndex];
+            }
+            if (fieldIndex <= 5 && 5 < idx) {
+                line.v5 = fieldValues[5 - fieldIndex];
+            }
+            yield __classPrivateFieldGet(this, _PrismaAdapter_prisma, "f").casbinRule.deleteMany({ where: line });
+        });
+    }
+    close() {
+        return __awaiter(this, void 0, void 0, function* () {
+            return __classPrivateFieldGet(this, _PrismaAdapter_prisma, "f").$disconnect();
+        });
+    }
+    static newAdapter(option) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const a = new PrismaAdapter(option);
+            yield __classPrivateFieldGet(a, _PrismaAdapter_open, "f").call(a);
+            return a;
+        });
+    }
+}
+exports.PrismaAdapter = PrismaAdapter;
+_PrismaAdapter_option = new WeakMap(), _PrismaAdapter_prisma = new WeakMap(), _PrismaAdapter_open = new WeakMap(), _PrismaAdapter_loadPolicyLine = new WeakMap(), _PrismaAdapter_savePolicyLine = new WeakMap();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "casbin-prisma-adapter",
-  "version": "1.6.0",
+  "version": "1.7.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "casbin-prisma-adapter",
-      "version": "1.6.0",
+      "version": "1.7.1",
       "devDependencies": {
         "@prisma/client": "^6.0.0",
         "@semantic-release/git": "^10.0.1",
         "@types/jest": "^28.1.6",
-        "@types/node": "^18.7.4",
+        "@types/node": "^22.10.1",
         "@typescript-eslint/eslint-plugin": "^3.4.0",
         "@typescript-eslint/parser": "^3.4.0",
         "casbin": "^5.16.0",
@@ -1649,10 +1649,14 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.7.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.5.tgz",
-      "integrity": "sha512-NcKK6Ts+9LqdHJaW6HQmgr7dT/i3GOHG+pt6BiWv++5SnjtRd4NXeiuN2kA153SjhXPR/AhHIPHPbrsbpUVOww==",
-      "dev": true
+      "version": "22.15.32",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.32.tgz",
+      "integrity": "sha512-3jigKqgSjsH6gYZv2nEsqdXfZqIFGAV36XYYjf9KGZ3PSG+IhLecqPnI310RvjutyMwifE2hhhNEklOUrvx/wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -9426,6 +9430,13 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/unique-string": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
@@ -11011,10 +11022,13 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.7.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.5.tgz",
-      "integrity": "sha512-NcKK6Ts+9LqdHJaW6HQmgr7dT/i3GOHG+pt6BiWv++5SnjtRd4NXeiuN2kA153SjhXPR/AhHIPHPbrsbpUVOww==",
-      "dev": true
+      "version": "22.15.32",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.32.tgz",
+      "integrity": "sha512-3jigKqgSjsH6gYZv2nEsqdXfZqIFGAV36XYYjf9KGZ3PSG+IhLecqPnI310RvjutyMwifE2hhhNEklOUrvx/wA==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~6.21.0"
+      }
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",
@@ -16668,6 +16682,12 @@
       "integrity": "sha512-uVbFqx9vvLhQg0iBaau9Z75AxWJ8tqM9AV890dIZCLApF4rTcyHwmAvLeEdYRs+BzYWu8Iw81F79ah0EfTXbaw==",
       "dev": true,
       "optional": true
+    },
+    "undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true
     },
     "unique-string": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casbin-prisma-adapter",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Prisma adapter for Casbin",
   "main": "lib/adapter.js",
   "typings": "lib/adapter.d.ts",

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -24,10 +24,11 @@ export class PrismaAdapter implements Adapter {
    * You should later call open() to activate it.
    */
   constructor(option?: Prisma.PrismaClientOptions | PrismaClient) {
-    if (option instanceof PrismaClient) {
-      this.#prisma = option;
-    } else {
-      this.#option = option;
+    if (option && typeof (option as PrismaClient).$connect === 'function') {
+      // If option is PrismaClient, we use it directly.
+      this.#prisma = option as PrismaClient;
+    } else if (option) {
+      this.#option = option as Prisma.PrismaClientOptions;
     }
   }
 

--- a/test/adapter.test.ts
+++ b/test/adapter.test.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { PrismaClient } from '@prisma/client';
 import { newEnforcer, Enforcer, Util } from 'casbin';
 import { PrismaAdapter } from '../src/adapter';
 
@@ -35,7 +36,8 @@ async function testGetGroupingPolicy(
 test(
   'TestAdapter',
   async () => {
-    const a = await PrismaAdapter.newAdapter();
+    const prisma = new PrismaClient();
+    const a = await PrismaAdapter.newAdapter(prisma);
 
     try {
       // Because the DB is empty at first,


### PR DESCRIPTION
This pull request introduces a new implementation of the `PrismaAdapter` class for integrating Casbin with Prisma, along with updates to the package version and related tests. The changes enhance functionality, improve type handling, and ensure compatibility with Prisma's client options.

### PrismaAdapter implementation:

* [`lib/adapter.js`](diffhunk://#diff-77fcec9d7bb0046cd062c60635550ae5ae61118b539f7653168e3251a6c9f85fR1-R217): Added a complete implementation of the `PrismaAdapter` class, including methods for loading, saving, adding, and removing policies using Prisma. This version supports both `PrismaClient` and `PrismaClientOptions` and includes private helper methods for policy handling.

### Package version update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the package version from `1.7.0` to `1.7.1` to reflect the new changes.

### Type handling improvements:

* [`src/adapter.ts`](diffhunk://#diff-90f5592a8a85ef6ea1f847351c4ec2ad2f646d34f426d1e9feb2ed7411f344ccL27-R31): Refactored the constructor of `PrismaAdapter` to correctly handle `PrismaClient` and `PrismaClientOptions` using type checks, ensuring better compatibility and flexibility.

### Test updates:

* `test/adapter.test.ts`: 
  - Imported `PrismaClient` to support the updated `PrismaAdapter` implementation.
  - Modified the test setup to explicitly pass a `PrismaClient` instance to `PrismaAdapter.newAdapter`.